### PR TITLE
Prevent dialog boxes from appearing after permissions are accepted

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.0" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/plcoding/permissionsguidecompose/MainActivity.kt
+++ b/app/src/main/java/com/plcoding/permissionsguidecompose/MainActivity.kt
@@ -38,23 +38,13 @@ class MainActivity : ComponentActivity() {
                 val viewModel = viewModel<MainViewModel>()
                 val dialogQueue = viewModel.visiblePermissionDialogQueue
 
-                val cameraPermissionResultLauncher = rememberLauncherForActivityResult(
-                    contract = ActivityResultContracts.RequestPermission(),
-                    onResult = { isGranted ->
-                        viewModel.onPermissionResult(
-                            permission = Manifest.permission.CAMERA,
-                            isGranted = isGranted
-                        )
-                    }
-                )
-
                 val multiplePermissionResultLauncher = rememberLauncherForActivityResult(
                     contract = ActivityResultContracts.RequestMultiplePermissions(),
                     onResult = { perms ->
                         permissionsToRequest.forEach { permission ->
                             viewModel.onPermissionResult(
                                 permission = permission,
-                                isGranted = perms[permission] == true
+                                isNotGranted = perms[permission] == false
                             )
                         }
                     }
@@ -65,13 +55,6 @@ class MainActivity : ComponentActivity() {
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Button(onClick = {
-                        cameraPermissionResultLauncher.launch(
-                            Manifest.permission.CAMERA
-                        )
-                    }) {
-                        Text(text = "Request one permission")
-                    }
                     Spacer(modifier = Modifier.height(16.dp))
                     Button(onClick = {
                         multiplePermissionResultLauncher.launch(permissionsToRequest)

--- a/app/src/main/java/com/plcoding/permissionsguidecompose/MainViewModel.kt
+++ b/app/src/main/java/com/plcoding/permissionsguidecompose/MainViewModel.kt
@@ -13,9 +13,9 @@ class MainViewModel: ViewModel() {
 
     fun onPermissionResult(
         permission: String,
-        isGranted: Boolean
+        isNotGranted: Boolean
     ) {
-        if(!isGranted && !visiblePermissionDialogQueue.contains(permission)) {
+        if(isNotGranted && !visiblePermissionDialogQueue.contains(permission)) {
             visiblePermissionDialogQueue.add(permission)
         }
     }


### PR DESCRIPTION
In my implementation, when one permission was permanently denied, dialog boxes for all permissions began prompting the user to navigate to settings and enable the respective permissions. The root of this issue lies in the way the iteration is handled:
```
    val multiplePermissionResultLauncher = rememberLauncherForActivityResult(
        contract = ActivityResultContracts.RequestMultiplePermissions(),
        onResult = { perms ->
            permissionsToRequest.forEach { permission ->
                viewModel.onPermissionResult(
                    permission = permission,
                    isNotGranted = perms[permission] == false
                )
            }
        }
    )

```
           
If a previously accepted permission is iterated over but not currently displayed, this iteration incorrectly flags it as not granted. Consequently, it gets added to the queue. This results in displaying dialog boxes even for permissions that were accepted earlier.
           